### PR TITLE
Remove 'pep585-upgrade'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Tools to upgrade to newer versions of Python or a framework.
 + [com2ann](https://github.com/ilevkivskyi/com2ann): translates type comments to type annotations.
 + [django-codemod](https://github.com/browniebroke/django-codemod): upgrades Django projects to newer version of the framework by automatically fixing deprecations.
 + [django-upgrade](https://github.com/adamchainz/django-upgrade): upgrades Django projects.
-+ [pep585-upgrade](https://github.com/snok/pep585-upgrade): upgrades type hints to the new native types implemented in PEP 585.
 + [pyupgrade](https://github.com/asottile/pyupgrade): upgrades syntax for newer versions of the language.
 
 ## Improvements and wrappers


### PR DESCRIPTION
`pep585-upgrade` is no longer maintained. You can check it by latest commit of the author https://github.com/snok/pep585-upgrade. Tools such as `pyupgrade`, mentioned in the readme of the package, is doing the same feature.