### PR TITLE
Remove Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Formatters that take care of all your code.
 
 + [autopep8](https://github.com/hhatto/autopep8): format Python code to conform to the PEP 8 style guide.
 + [black](https://github.com/python/black): uncompromising Python code formatter.
-+ [prettier](https://github.com/prettier/prettier): opinionated code formatter, not only for Python.
 + [yapf](https://github.com/google/yapf): yet another Python code formatter from Google.
 
 ## UNIX-way formatters


### PR DESCRIPTION
Prettier's Python plugin is currently deprecated and is recommending the use of Black, instead, as you can see on their repository: https://github.com/prettier/plugin-python